### PR TITLE
Update index1.md

### DIFF
--- a/index1.md
+++ b/index1.md
@@ -2,7 +2,7 @@
 
 En el mundo de las TIC hay varias herramientas de autor que puede utilizar el profesorado sin necesidad de ser un experto informático: Edilim, Educaplay, Ardora, Constructor y Cuadernia estarían entre las más adecuadas para trabajar en Educación Infantil.
 
-Como verás en la Unidad 2, vamos a hacer especial hincapié en **Edilim** por su fácil manejo, su variedad de actividades  y atractivo visual. De todas formas, tal como hacemos a lo largo de todo el curso, te vamos a proponer **otras alternativas** para que materialices las actividades del Proyecto de Trabajo que quieres hacer con tu alumnado.
+Como verás en la Unidad 2, vamos a hacer especial hincapié en **Educaplay** por su fácil manejo, su variedad de actividades  y atractivo visual. De todas formas, tal como hacemos a lo largo de todo el curso, te vamos a proponer **otras alternativas** para que materialices las actividades del Proyecto de Trabajo que quieres hacer con tu alumnado.
 
 ## Objetivos
 


### PR DESCRIPTION
Ponía Edilim pero se han eliminado los contenidos de Edilim que estaban integrados en el curso. Después se hace alguna referencia residual a este programa en algún apartado y se pide elaborar actividades con él en la tarea del módulo 2.
La única información sobre edilim está fuera de los contenidos normales en un documento de word que preparé en 2017... Yo veo dos opciones para ajustar esto: se puede eliminar todo rastro de edilim del curso y quitarlo también de la tarea o incluirlo en los contenidos... 
A mí me parece más fácil y que tiene un aspecto más actual Educaplay... 
Así que os mando los contenidos modificados como si se quitara edilim... luego ya vosotros decidís si usáis esto, si se deja como está o si se apaña de otra forma.